### PR TITLE
Fixed Rake tasks loading and definition

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,25 @@
-require "yast/rake"
+# the tasks initialization done in "libyui/rake" reads some
+# packaging files which do not exist in this container "package",
+# create some dummy files before loading so it does not fail
+# TODO: fix the "libyui/rake" and remove this workaround
+FAKE_SPEC_FILE = "package/fake.spec".freeze
+FAKE_VERSION_FILE = "VERSION.cmake"
+FAKE_VERSION_CONTENT = "SET(VERSION_MAJOR \"42\")\n" \
+"SET(VERSION_MINOR \"42\")\nSET(VERSION_PATCH \"42\")".freeze
 
-Yast::Tasks.configuration do |conf|
+begin
+  # just an empty file is enough
+  File.write(FAKE_SPEC_FILE, "")
+  File.write(FAKE_VERSION_FILE, FAKE_VERSION_CONTENT)
+
+  require "libyui/rake"
+ensure
+  # ensure the fake files are deleted
+  File.delete(FAKE_SPEC_FILE) if File.exist?(FAKE_SPEC_FILE)
+  File.delete(FAKE_VERSION_FILE) if File.exist?(FAKE_VERSION_FILE)
+end
+
+Libyui::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/
 


### PR DESCRIPTION
I copied the Rakefile from an YaST repository which obviously uses `yast/rake` instead of `libyui/rake`.

The result was a failure in Jenkins: https://ci.opensuse.org/view/libyui/job/libyui-ci-libyui-container-master/2/console because it wants to submit to YaST:Head OBS project.

Unfortunately the libyui tasks expect some files which do not exist in this container "package". As a workaround create some dummy files before loading it. (Later we should fix the tasks to not crash when some files are missing.)