### PR TITLE
Remove the Gtk plugin (bsc#1159736)

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -25,12 +25,10 @@ RUN zypper --non-interactive install --no-recommends \
   fontconfig-devel \
   gcc-c++ \
   git \
-  gtk3-devel \
   lcov \
   jsoncpp-devel \
   libmicrohttpd-devel \
   libyui-devel \
-  libyui-gtk-devel \
   libyui-ncurses-devel \
   libyui-qt-devel \
   libyui-rest-api-devel \


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1159736
- Gtk UI does not compile at all and just blocks the other plugins (OBS still uses the old available libyui-gtk10 which is not compatible with the latest libyui11)

The Gtk UI currently does not build, it fails because of many deprecation errors from Gtk3 (https://build.opensuse.org/package/live_build_log/devel:libraries:libyui/libyui-gtk/openSUSE_Factory/x86_64). The easiest workaround is to remove it from the Docker image for now.

The Gtk plugin will then fail at Travis but as it would fail anyway (because of that deprecation errors) it's not a regression. If somebody touches the Gtk plugin then they will need to fix also the deprecation errors. And then we can add it back to the Docker image...