### PR TITLE
Fixed Docker image build

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -52,7 +52,6 @@ RUN zypper --non-interactive install --no-recommends \
   && zypper clean --all \
   && rm -rf /usr/lib*/ruby/gems/*/cache/ \
   && rm -rf /usr/share/doc/ \
-  && rpm -e --nodeps kbd kbd-legacy \
   && find /usr/lib/locale/* -maxdepth 1 | grep -v -E "(en_US|cs_CZ|es_ES|de_DE|C.utf8)" | xargs rm -rf \
   && find /usr/share/locale -name "*.mo" -delete
 


### PR DESCRIPTION
- Fixes a build problem in OBS ("error: package kbd is not installed", "error: package kbd-legacy is not installed")
  - https://build.opensuse.org/package/live_build_log/devel:libraries:libyui/ci-libyui-container/containers/x86_64
- The "kbd" and "kbd-legacy" packages are no more pulled in by some dependencies.