### PR TITLE
Install needed packages

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -27,6 +27,10 @@ RUN zypper --non-interactive install --no-recommends \
   git \
   graphviz \
   lcov \
+  swig \
+  python-devel \
+  ruby-devel \
+  graphviz-devel \
   jsoncpp-devel \
   libmicrohttpd-devel \
   libyui-devel \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -2,9 +2,9 @@
 #!BuildTag: libyui-devel
 
 # NOTE: when building in OBS it actually is this image:
-# https://build.opensuse.org/package/show/devel:libraries:libyui/opensuse-tumbleweed-image
+# https://build.opensuse.org/package/show/devel:libraries:libyui/opensuse-15_3-image:docker
 # not the Docker hub image!!
-FROM opensuse/tumbleweed
+FROM opensuse/leap:15.3
 
 # do not install the files marked as documentation (use "rpm --excludedocs")
 RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf
@@ -14,7 +14,7 @@ COPY devel:libraries:libyui.pub /usr/share/gpg-keys/
 RUN rpm --import /usr/share/gpg-keys/devel:libraries:libyui.pub
 
 # Add the libyui repository
-RUN zypper ar -f http://download.opensuse.org/repositories/devel:/libraries:/libyui/openSUSE_Tumbleweed/ libyui
+RUN zypper ar -f http://download.opensuse.org/repositories/devel:/libraries:/libyui/openSUSE_Leap_15.3/ libyui
 
 RUN zypper --non-interactive install --no-recommends \
   boost-devel \


### PR DESCRIPTION
### Problem

We are merging all libyui repositories into a single repository. Now, all the subpackages will be built in only one shot as part of the CI check. Some libyui subpackages (i.e., libyui-bindings and libyui-qt-graph) require some extra packages that are not included in the libyui docker image.


### Solution 

Extend the libyui docker image definition to include all the required packages.

NOTE: For the time being, Leap 15.3 base image is used instead of TW one. This avoids to use the last glibc which does not work well with docker containers running on Ubuntu systems.
