### PR TITLE
Fix Docker image build

### DIFF
--- a/ci-test
+++ b/ci-test
@@ -7,7 +7,7 @@ trap "mv package/Dockerfile.bak package/Dockerfile" EXIT
 
 # when we build the image in OBS the FROM actually refers to the OBS image,
 # if we want to use the same image at GitHub build we need to patch the Dockerfile
-sed -i.bak -e 's@^FROM .*$@FROM registry.opensuse.org/devel/libraries/libyui/images/opensuse/tumbleweed@' package/Dockerfile
+sed -i.bak -e 's@^FROM .*$@FROM registry.opensuse.org/yast/head/images/opensuse/tumbleweed@' package/Dockerfile
 
 # build the Docker image
 docker build -t libyui-test -f package/Dockerfile package/

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -19,7 +19,6 @@ RUN zypper ar -f http://download.opensuse.org/repositories/devel:/libraries:/lib
 RUN zypper --non-interactive install --no-recommends \
   boost-devel \
   brp-check-suse \
-  brp-extract-appdata \
   cmake \
   doxygen \
   fontconfig-devel \


### PR DESCRIPTION
- The `brp-extract-appdata` package has been dropped from Factory, remove it from the list
- The Docker image uses the base from YaST:Head to avoid duplicates, fix the GitHub Action to work again